### PR TITLE
Make it possible to click buttons outside of the circle but inside of the rectangle

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
             left: 0;
             position: absolute;
             top: 0;
+            border-radius: 50%;
         }
 
         .map-select {


### PR DESCRIPTION
Make the cursor element only take up the space for the image. Thus make is possible to click a map button just outside the cursor image.